### PR TITLE
chore(ci): use meza ubuntu slim runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Release:
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

Replace `runs-on: self-hosted` with `runs-on: meza-ubuntu-slim` in 1 GitHub Actions workflow file.

## Validation

- Verified 1 exact runner-label replacement.
- Verified no other staged lines changed.
- `git diff --check` passes.